### PR TITLE
Fix/(#13)bluetooth connection exception handling

### DIFF
--- a/drawingnote_application/lib/features/connectionPage/connection_page.dart
+++ b/drawingnote_application/lib/features/connectionPage/connection_page.dart
@@ -38,6 +38,8 @@ class _ConnectionPageState extends State<ConnectionPage> {
       pagedata: _pagedata,
     );
 
+    _bluetoothmanager.bluetoothClassicPlugin.disconnect();
+
     //httpmanager의 ip주소 변경 감지하여 UI 업데이트
     _httpmanager.ipAddress.addListener(() {
       if (kDebugMode) {

--- a/drawingnote_application/lib/services/bluetoothmanager.dart
+++ b/drawingnote_application/lib/services/bluetoothmanager.dart
@@ -116,7 +116,22 @@ class Bluetoothmanager {
 
   ///device 연결 함수
   Future<void> connectDevice(String address) async {
-    await _bluetoothClassicPlugin.connect(address, _serviceUUID);
+    //이미 연결 중인 경우 return
+    if (deviceStatus.value == 1) {
+      return;
+    }
+    //이미 연결된 경우 연결 끊고 다시 연결
+    else if (deviceStatus.value == 2) {
+      await _bluetoothClassicPlugin.disconnect();
+    }
+
+    try {
+      await _bluetoothClassicPlugin.connect(address, _serviceUUID);
+    } catch (e) {
+      if (kDebugMode) {
+        print('Conntection Error : $e');
+      }
+    }
   }
 
   //--------------------------------------------------------------------------------


### PR DESCRIPTION
- connection Page 초기 진입 시 블루투스 연결 끊도록 설계
- 블루투스 기기 연결 시도 시, 연결 상태에 따라 다르게 처리하도록 로직 추가
   - 연결 중인 경우에는 시도하지 않음
   - 이미 연결되어 있는 경우, 기존 연결을 끊고 연결을 시도함
   - 미연결 상태인 경우, 기존처럼 연결 시도